### PR TITLE
Correct file name typo in index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,7 +25,7 @@
     <div>
         <div class="uk-container uk-margin-medium-top uk-margin-medium-bottom">
             <div class="uk-text-center" id="userCards" uk-grid uk-height-match="target: > div > .uk-card; row: false">
-                 <!-- To be populated by userMapping.js  -->
+                 <!-- To be populated by nameMapping.js  -->
             </div>
         </div>
     </div>    


### PR DESCRIPTION
The HTML comment said the file was `userMapping.js` when it was actually `nameMapping.js`.